### PR TITLE
OPCUA Setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 __pycache__/
 *.db
 env/
+*.pickle

--- a/application/src/model/databaseConnection.py
+++ b/application/src/model/databaseConnection.py
@@ -94,7 +94,7 @@ class dataBase:
             self.conn.commit()
             return
         else: # Date already contains a message
-            newMessage = messageExists[0][1] + '\n\n' + message
+            newMessage = messageExists[0][1] + '\n' + message
             self.conn.execute(''' UPDATE messages SET message = ? WHERE date = ?; ''', (newMessage, date))
             self.conn.commit()
             return

--- a/runtime/schedulerRuntime.py
+++ b/runtime/schedulerRuntime.py
@@ -6,6 +6,7 @@ import os
 
 pathToDB = os.getenv("APPDATA") + "\\ScheduleTrak"
 os.makedirs(pathToDB, exist_ok=True)
+pathToPickle = pathToDB + "\\schedules.pickle"
 pathToDB += "\\scheduleTrakDB.db"
 
 user = os.getenv("py_outlook_user")
@@ -19,6 +20,6 @@ if user is None or pas is None or send is None:
 
 reader = ExcelReader()
 
-controller = schedulerRuntimeController(reader, "", pathToDB)
+controller = schedulerRuntimeController(reader, "", pathToDB, pathToPickle)
 
 controller.startRuntime()

--- a/runtime/src/controller/runtimeController.py
+++ b/runtime/src/controller/runtimeController.py
@@ -32,7 +32,10 @@ class schedulerRuntimeController:
             self.findPath()
             self.findEmails()
             currentTime = datetime.now().strftime("%H:%M")
-            if currentTime == self.__time or self.DEBUGsend:
+
+            dayOfWeek = datetime.date.today().weekday()
+
+            if (currentTime == self.__time and dayOfWeek < 5) or self.DEBUGsend:
                 self.Email = Emailer()
                 today = self.getToday() # Today must be acquired before the key
                 try:
@@ -40,12 +43,13 @@ class schedulerRuntimeController:
                 except Exception as e:
                     print("An error has occurred with reading the file given.  Are you sure it is formatted correctly?: " + e)
                     return None
+                self.todaysMessage = self.database.getMessages(date.today().strftime("%Y-%m-%d")) # Expect String
                 self.__pickleTodaysData(self.pathToPickle)
-                self.Email.sendDailyUpdate(self.__emailList, today, self.reader.getKey(), self.database.getMessages(date.today().strftime("%Y-%m-%d")))
+                self.Email.sendDailyUpdate(self.__emailList, today, self.reader.getKey(), self.todaysMessage)
                 self.Email.logout()
                 del self.Email
                 self.DEBUGsend = False
-            print('Sleeping... ')
+            print('Sleeping... @ ' + currentTime)
             time.sleep(60) 
 
     def findTime(self):
@@ -84,3 +88,4 @@ class schedulerRuntimeController:
         with open(path, 'wb') as f:
             pickle.dump(self.readerKey, f, pickle.HIGHEST_PROTOCOL)
             pickle.dump(self.__today, f, pickle.HIGHEST_PROTOCOL)
+            pickle.dump(self.todaysMessage, f, pickle.HIGHEST_PROTOCOL)

--- a/runtime/src/controller/runtimeController.py
+++ b/runtime/src/controller/runtimeController.py
@@ -33,7 +33,7 @@ class schedulerRuntimeController:
             self.findEmails()
             currentTime = datetime.now().strftime("%H:%M")
 
-            dayOfWeek = datetime.date.today().weekday()
+            dayOfWeek = date.today().weekday()
 
             if (currentTime == self.__time and dayOfWeek < 5) or self.DEBUGsend:
                 self.Email = Emailer()

--- a/runtime/src/controller/runtimeController.py
+++ b/runtime/src/controller/runtimeController.py
@@ -31,6 +31,11 @@ class schedulerRuntimeController:
             if currentTime == self.__time or self.DEBUGsend:
                 self.Email = Emailer()
                 today = self.getToday() # Today must be acquired before the key
+                try:
+                    self.readerKey = self.reader.getKey()
+                except Exception as e:
+                    print("An error has occurred with reading the file given.  Are you sure it is formatted correctly?: " + e)
+                    return None
                 self.Email.sendDailyUpdate(self.__emailList, today, self.reader.getKey(), self.database.getMessages(date.today().strftime("%Y-%m-%d")))
                 self.Email.logout()
                 del self.Email
@@ -56,7 +61,10 @@ class schedulerRuntimeController:
             print(e)
 
     def getToday(self):
-        self.__today = self.reader.getTodaysSchedule()
+        try:
+            self.__today = self.reader.getTodaysSchedule()
+        except Exception as e:
+            print("An error has occurred with reading the file given.  Are you sure it was formatted correctly?: " + e)
         self.database.clearSchedule()
         for rowNum, i in enumerate(self.__today):
             if rowNum == 0:

--- a/runtime/src/model/opcuaPyServer.py
+++ b/runtime/src/model/opcuaPyServer.py
@@ -1,7 +1,10 @@
 import asyncio
 import logging
+import pickle
+import os
 from datetime import datetime
 from typing import List, Tuple, Any
+from time import sleep
 
 from asyncua import Server, ua
 from asyncua.common.methods import uamethod
@@ -11,6 +14,7 @@ class SchedulerOPCpyServer:
         self.uri = uri
         self.objects = objects
         self.allObjects = {}
+        self.launchServer()
 
     async def main(self):
         _logger = logging.getLogger(__name__)
@@ -70,13 +74,44 @@ class SchedulerOPCpyServer:
         return await obj[variableName].get_value()
 
 
+# sleep(5)
+
+pathToPickle = os.getenv("APPDATA") + "\\ScheduleTrak"
+os.makedirs(pathToPickle, exist_ok=True)
+pathToPickle += "\\schedules.pickle"
+
+colorKey = []
+schedules = []
+
+with open(pathToPickle, 'rb') as f:
+    colorKey = pickle.load(f)
+    schedules = pickle.load(f)
+
+colorKeyForOPCUA = ["colorKey", []]
+names = ["names", []]
+jobs = ["jobs", []]
+locations = ["locations", []]
+
+for i in colorKey:
+    colorKeyForOPCUA[1].append((colorKey[i], i))
+
+for num, i in enumerate(schedules):
+    if num == 0:
+        continue
+    person = 'Person' + str(num)
+    names[1].append((person, str(i[0])))
+    jobs[1].append((person, str(i[1])))
+    locations[1].append((person, str(i[2])))
+
 
 number = 125
 number2 = 42
 string = "123 Test String 123"
-serv = SchedulerOPCpyServer("https://dentechindustrial.com/ScheduleTrak", [["NEWmyObjectNEW", [("NEWmyVarNEW", number), ("AnotherTag", number2), ("PerhapsAString", string)]]])
 
-serv.launchServer()
+serv = SchedulerOPCpyServer("https://dentechindustrial.com/ScheduleTrak", [["NEWmyObjectNEW", [("NEWmyVarNEW", number), ("AnotherTag", number2), ("PerhapsAString", string)]],
+                                                                          colorKeyForOPCUA, jobs, locations, names])
+
+
 
 
 


### PR DESCRIPTION
Changes made for hosting the OPCUA server and sending the data from the runtime to an Ignition Project.

++ Added some error checking on reading in Excel files so that the runtime won't just crash without explanation
++ .pickle files have been added to the gitignore
++ Pickled data is being used to transfer from the Python Runtime to the Python OPCUA server, which will exist as separate processes.  The Pickle data lives in AppData\ScheduleTrak
++ OPCUA tags are now being hosted from the script.  Current implementation has not been thoroughly tested as time has gone towards the Ignition SCADA View (which will be uploaded via a different branch)
!! Note that OPCUA tags are currently not being dynamically updated, they are defined upon startup.  This was mostly done to assure that it was possible to send pickled data to an Ignition project, and it was usable.  Future work will need to make sure that this data is dynamic.

~~ New messages per day have been given a single newline instead of a double newline as it saves screen space for the Ignition Project.
~~ Runtime controller has been changed to accept a pickle path as an argument.  This is the path all pickled data will be saved to.
~~ A Bug has been fixed where the emailer would send emails on the weekend